### PR TITLE
[wip] Building template generation feature into spike-rooftop

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ new Rooftop({
 })
 ```
 
+Using the template option allows you to write objects returned from Rooftop to single page templates. For example, if you are trying to render a blog as static, you might want each post returned from the API to be rendered as a single page by itself.
+
+The template option is an object with path and output keys. path is an absolute or relative path to a template to be used to render each item, and output is a function with the currently iterated item as a parameter, which should return a string representing a path relative to the project root where the single view should be rendered. For example:
+
+```js
+const locals = {}
+
+new Rooftop({
+  addDataTo: locals,
+  name: 'xxx',
+  apiToken: 'xxx',
+  contentTypes: [{
+    name: 'posts',
+    template: : {
+      path: 'templates/post.html',
+      output: (post) => { return `posts/${post.slug}.html` }
+    }
+  }]
+})
+```
+
 Finally, if you'd like to have the output written locally to a JSON file so that it is effectively cached locally, you can pass the name of the file, resolved relative to your project's output, as a `json` option to the plugin. For example:
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,10 @@
 const Client = require('rooftop-client')
 const Joi = require('joi')
 const W = require('when')
+const fs = require('fs')
+const path = require('path')
+const node = require('when/node')
+const posthtml = require('posthtml')
 
 class Rooftop {
   constructor (opts) {
@@ -20,7 +24,14 @@ class Rooftop {
           size: () => src.length
         }
       }
-      done()
+
+      const templateContent = this.contentTypes.filter((ct) => {
+        return ct.template
+      })
+
+      W.map(templateContent, (ct) => {
+        return writeTemplate(ct, compiler, compilation, this.addDataTo)
+      }).done(() => done(), done)
     })
   }
 
@@ -103,5 +114,32 @@ function transform (post) {
   return post
 }
 
+function writeTemplate (ct, compiler, compilation, addDataTo) {
+  const data = addDataTo.rooftop[ct.name]
+  const filePath = path.join(compiler.options.context, ct.template.path)
+
+  return node.call(fs.readFile.bind(fs), filePath, 'utf8')
+    .then((template) => {
+      return data.map((item) => {
+        addDataTo = Object.assign(addDataTo, { item: item })
+        compiler.request = filePath
+        let plugins = compiler.options.posthtml
+        if (typeof plugins === 'function') plugins = plugins.call(this, compiler)
+        if (typeof plugins === 'object') plugins = plugins.defaults
+
+        return posthtml(plugins)
+          .process(template)
+          .then((r) => r.html)
+          .then((rendered) => {
+            compilation.assets[ct.template.output(item)] = {
+              source: () => rendered,
+              size: () => rendered.length
+            }
+          })
+      })
+    })
+}
+
+// module.exports.writeTemplate = writeTemplate
 module.exports = Rooftop
 module.exports.transform = transform

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "version": "0.3.0",
   "author": "Jeff Escalante",
   "ava": {
-    "verbose": "true"
+    "verbose": "true",
+    "serial": "true"
   },
   "bugs": "https://github.com/static-dev/spike-rooftop/issues",
   "dependencies": {
     "rooftop-client": "0.0.2",
-    "when": "^3.7.7"
+    "when": "^3.7.7",
+    "posthtml": "^0.8.7"
   },
   "devDependencies": {
     "ava": "^0.15.2",
@@ -17,6 +19,7 @@
     "dotenv": "^2.0.0",
     "nyc": "^6.4.4",
     "posthtml-jade": "^0.8.2",
+    "posthtml-exp": "^0.8.1",
     "rimraf": "^2.5.2",
     "spike-core": "^0.8.0",
     "standard": "^7.1.2"

--- a/test/fixtures/template/template.html
+++ b/test/fixtures/template/template.html
@@ -1,0 +1,1 @@
+<p>{item.title}</p>


### PR DESCRIPTION
Building a template-generation feature for spike-rooftop, allowing users to pass RooftopCMS content through a jade template to automatically generate html files, similar to what we have in spike-records.

Work in progress!