### PR TITLE
Change default transform to accommodate "repeater" and "relationship" fields.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,6 +100,25 @@ function validate (opts = {}) {
  * @private
  */
 function transform (post) {
+  const mapItem = (item) => {
+    item.advanced = item.advanced || item.content.advanced
+    item.content = item.content || {}
+    if (item.advanced) {
+      item.advanced.map((c) => {
+        c.fields.map((field) => {
+          if (field.class === "repeater") {
+            item.content[field.name] = field.fields.map((row) => row[0])
+          } else if (field.class === "relationship" && field.value) {
+            item.content[field.name] = field.value
+            item.content[field.name].map(mapItem)
+          } else {
+            item.content[field.name] = field.value
+          }
+        })
+      })
+      delete item.advanced
+    }
+  }
   post.title = post.title.rendered
   delete post.guid
   delete post.link
@@ -107,10 +126,7 @@ function transform (post) {
   post.content.basic = post.content.basic.content
   post.content.excerpt = post.content.basic.excerpt
   if (!post.content.excerpt) delete post.content.excerpt
-  post.content.advanced.map((c) => {
-    c.fields.map((f) => { post.content[f.name] = f.value })
-  })
-  delete post.content.advanced
+  mapItem(post)
   return post
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -46,7 +46,7 @@ test.cb('returns valid content', (t) => {
   })
 
   api.run(compilerMock, undefined, () => {
-    t.is(locals.rooftop.posts.length, 2)
+    t.is(locals.rooftop.posts.length, 5)
     t.is(locals.rooftop.case_studies.length, 1)
     t.end()
   })
@@ -148,7 +148,7 @@ test.cb('works as a plugin to spike', (t) => {
   project.on('warning', t.end)
   project.on('compile', () => {
     const src = fs.readFileSync(path.join(projectPath, 'public/index.html'), 'utf8')
-    t.truthy(src === '91')
+    t.truthy(src === '101969391')
     rimraf.sync(path.join(projectPath, 'public'))
     t.end()
   })
@@ -212,4 +212,45 @@ test.cb('accepts template object and generates html', (t) => {
   })
 
   project.compile()
+})
+
+test.cb('default transform handles repeater items', (t) => {
+  const locals = {}
+  const api = new Rooftop({
+    name: process.env.name,
+    apiToken: process.env.token,
+    addDataTo: locals,
+    contentTypes: [{
+      name: 'articles'
+    }]
+  })
+
+  api.run(compilerMock, undefined, () => {
+    for (let i = 0; i < 3; i++) {
+      t.is(locals.rooftop.articles[3].content.repeater_test[i].value, `${i}`)
+    }
+    t.end()
+  })
+})
+
+test.cb('default transform works on relationship items', (t) => {
+  const locals = {}
+  const api = new Rooftop({
+    name: process.env.name,
+    apiToken: process.env.token,
+    addDataTo: locals,
+    contentTypes: [{
+      name: 'articles'
+    }]
+  })
+
+  api.run(compilerMock, undefined, () => {
+    let testArticle = locals.rooftop.articles[3]
+    t.truthy(testArticle.content.relationship_test)
+    for (let i = 0; i < 3; i++) {
+      testArticle = testArticle.content.relationship_test[0]
+      t.is(testArticle.title, `Test Article ${i}`)
+    }
+    t.end()
+  })
 })


### PR DESCRIPTION
#### Add support for "repeater" field
Currently the default transform will remove "repeater" field items before it makes it to the `rooftop` local. This occurs because repeaters don't have a `value` property, instead they have a `fields` property, which is an array of the repeater items.

Spike rooftop line that uses `value`:
```javascript
post.content[f.name] = f.value
```

JSON for repeater items:
```
{
  "name": "case_images",
  "label": "Case Images",
  "class": "repeater",
  "fields": [...]
}
```

#### Add support for "relationship" field
Currently the default transform will keep "relationship" field items, but not touch them otherwise. This PR will transform the JSON for relationship items to look like the structure for regular items. Ex: Advanced fields for nested relationship items can now be found in `post.content`