### PR TITLE
Issue 26: Change to use compiler.resourcePath in writeTemplate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,7 @@ function writeTemplate (ct, compiler, compilation, addDataTo) {
     .then((template) => {
       return data.map((item) => {
         addDataTo = Object.assign(addDataTo, { item: item })
-        compiler.request = filePath
+        compiler.resourcePath = filePath
         let plugins = compiler.options.posthtml
         if (typeof plugins === 'function') plugins = plugins.call(this, compiler)
         if (typeof plugins === 'object') plugins = plugins.defaults
@@ -156,6 +156,5 @@ function writeTemplate (ct, compiler, compilation, addDataTo) {
     })
 }
 
-// module.exports.writeTemplate = writeTemplate
 module.exports = Rooftop
 module.exports.transform = transform


### PR DESCRIPTION
Closes #26 

This PR adjusts spike-rooftop to work with the default posthtml config for spike. Currently the default spike config for posthtml uses `ctx.resourcePath`. This PR updates the `writeTemplate` function to set this property, so spike-rooftop will work correctly by default.

Spike config:
```javascript
  posthtml: (ctx) => {
    return {
      defaults: [
        jade({ filename: ctx.resourcePath, pretty: true, foo: 'bar' }),
        md(),
        retext([smartypants])
      ]
    }
  }
```