### PR TITLE
Issue 27 - generate errors when templates are incorrect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ class Rooftop {
       })
 
       W.map(templateContent, (ct) => {
-        return writeTemplate(ct, compiler, compilation, this.addDataTo)
+        return writeTemplate(ct, compiler, compilation, this.addDataTo, done)
       }).done(() => done(), done)
     })
   }
@@ -131,7 +131,7 @@ function transform (post) {
   return post
 }
 
-function writeTemplate (ct, compiler, compilation, addDataTo) {
+function writeTemplate (ct, compiler, compilation, addDataTo, cb) {
   const data = addDataTo.rooftop[ct.name]
   const filePath = path.join(compiler.options.context, ct.template.path)
 
@@ -144,13 +144,12 @@ function writeTemplate (ct, compiler, compilation, addDataTo) {
         const options = loader.parseOptions(compiler.options.posthtml)
         return posthtml(options.plugins)
           .process(template)
-          .then((r) => r.html)
-          .then((rendered) => {
+          .then((res) => {
             compilation.assets[ct.template.output(item)] = {
-              source: () => rendered,
-              size: () => rendered.length
+              source: () => res.html,
+              size: () => res.html.length
             }
-          })
+          }, cb)
       })
     })
 }

--- a/test/fixtures/template/error.html
+++ b/test/fixtures/template/error.html
@@ -1,0 +1,1 @@
+<p>{{ notItem.title }}</p>

--- a/test/index.js
+++ b/test/index.js
@@ -148,7 +148,7 @@ test.cb('works as a plugin to spike', (t) => {
   project.on('warning', t.end)
   project.on('compile', () => {
     const src = fs.readFileSync(path.join(projectPath, 'public/index.html'), 'utf8')
-    t.truthy(src === '101969391')
+    t.truthy(src === '101969391') // post IDs from carrotcreativedemo
     rimraf.sync(path.join(projectPath, 'public'))
     t.end()
   })
@@ -207,6 +207,39 @@ test.cb('accepts template object and generates html', (t) => {
     const file2 = fs.readFileSync(path.join(projectPath, 'public/posts/Welcome to Rooftop.html'), 'utf8')
     t.is(file1.trim(), '<p>Testing 123</p>')
     t.is(file2.trim(), '<p>Welcome to Rooftop</p>')
+    rimraf.sync(path.join(projectPath, 'public'))
+    t.end()
+  })
+
+  project.compile()
+})
+
+test.cb('generates error if template has an error', (t) => {
+  const locals = {}
+  const rooftop = new Rooftop({
+    name: process.env.name,
+    apiToken: process.env.token,
+    addDataTo: locals,
+    contentTypes: [{
+      name: 'case_studies',
+      template: {
+        path: '../template/error.html',
+        output: (item) => `posts/${item.title}.html`
+      }
+    }]
+  })
+
+  const projectPath = path.join(__dirname, 'fixtures/default')
+  const project = new Spike({
+    root: projectPath,
+    posthtml: { plugins: [exp({ locals })] },
+    entry: { main: [path.join(projectPath, 'main.js')] },
+    plugins: [rooftop]
+  })
+
+  project.on('warning', t.end)
+  project.on('error', (error) => {
+    t.is(error.message.message, 'notItem is not defined')
     rimraf.sync(path.join(projectPath, 'public'))
     t.end()
   })


### PR DESCRIPTION
Closes #27 

Add callback to writeTemplate, so that errors are generated when writeTemplate fails.