### PR TITLE
Use SpikeUtil to get spike options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const Client = require('rooftop-client')
 const Joi = require('joi')
+const SpikeUtil = require('spike-util')
 const W = require('when')
 const fs = require('fs')
 const path = require('path')
@@ -145,6 +146,8 @@ function transform (post) {
 function writeTemplate (ct, compiler, compilation, addDataTo, cb) {
   const data = addDataTo.rooftop[ct.name]
   const filePath = path.join(compiler.options.context, ct.template.path)
+  const util = new SpikeUtil(compiler.options)
+  const spikeOptions = util.getSpikeOptions()
 
   return node.call(fs.readFile.bind(fs), filePath, 'utf8')
     .then((template) => {
@@ -155,7 +158,7 @@ function writeTemplate (ct, compiler, compilation, addDataTo, cb) {
         // webpack context is used by default in spike for plugins, so we need
         // to mock it so that plugins dont crash
         const fakeContext = { addDependency: (x) => x, resourcePath: filePath }
-        const options = loader.parseOptions.call(fakeContext, compiler.options.reshape)
+        const options = loader.parseOptions.call(fakeContext, spikeOptions.reshape)
 
         // W.map fires events as quickly as possible, so the locals will be
         // swapped for the last item unless bound to the result function

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "reshape": "^0.4.0",
     "reshape-loader": "^0.4.0",
     "rooftop-client": "^0.2.1",
-    "spike-util": "^0.4.0",
+    "spike-util": "^1.0.0",
     "when": "^3.7.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "reshape": "^0.4.0",
     "reshape-loader": "^0.4.0",
     "rooftop-client": "^0.2.1",
+    "spike-util": "^0.4.0",
     "when": "^3.7.7"
   },
   "devDependencies": {


### PR DESCRIPTION
For the most part, 0.10.1 appears to work well with spike-core 1.0. But compiling templates is resulting in templates which are not getting transformed (so the resulting .html for a post has exactly the same content as the original template). After some digging around, I found something that works for me and decided to send it as a PR.

Apologies for not adding tests, and for any other mistakes - I am very new to the world of (node)js.

---

Provides forward compatibility with spike-core 1.0. See also
https://gist.github.com/jescalan/8e39596765c66a192d00c2684437bf57#custom-plugin-updates .

Since spike-core 0.13.3 has the dependency `"spike-util": "^0.4.0"`, we should get 0.5.0-0 which introduces the `getSpikeOptions()` function. This should provide forward compatibility with spike-core 1.0.